### PR TITLE
Introduce Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,9 +69,9 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 GraphQL Summit prioritizes marginalized people’s safety over privileged people’s comfort. The administrators will not act on complaints regarding:
 
-- “Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia”
-- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
-- Communicating in a “tone” you don’t find congenial
+- “Reverse”-isms, including "reverse racism," "reverse sexism," and "cisphobia"
+- Reasonable communication of boundaries, such as "leave me alone," "go away," or "I’m not discussing this with you."
+- Communicating in a "tone" you don’t find congenial
 - Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
 - The examples listed above are not against the Code of Conduct.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+## Apollo Code of Conduct
+
+If you see a Code of Conduct violation, follow these steps:
+
+- Let the person know that what they did is not appropriate and ask them to stop and/or edit their message(s) if online.
+- That person should immediately stop the behavior and correct the issue.
+- If this doesn’t happen, or if you’re uncomfortable speaking up, contact organizers by emailing [codeofconduct@graphql.com](mailto:codeofconduct@graphql.com).
+- As soon as available, an organizer will respond, identify themselves, and take further action (see below), starting with a warning, then temporary deactivation, then long-term deactivation.
+- When reporting, please include any relevant details, links, screenshots, context, or other information that may be used to better understand and resolve the situation.
+- The Admin team will prioritize the well-being and comfort of those affected negatively by the violation over the comfort of the violator. This may include the violator being removed from online or in-person spaces until those affected say they would feel safe with the person returning.
+
+### Our Goal
+
+This community is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+
+### Applicability and Scope
+
+This code of conduct applies to all of this community's spaces, including public channels, private channels and direct messages, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the administrators.
+
+### Toward a Welcoming and Safe Environment
+
+We hope to create an environment in which diverse individuals can collaborate and interact in a positive and affirming way. Examples of behavior that contributes to creating this sort of environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the overall community
+- Showing empathy towards other community members
+
+### Anti-Harassment Statement
+
+This community will not tolerate harassment of any kind. Examples of harassment include:
+
+- Offensive comments, usernames, and emoji related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, pregnancy status, veteran status, political affiliation, marital status, body size, age, race, national origin, ethnic origin, nationality, immigration status, language, religion or lack thereof, or other identity markers. This includes anti-Indigenous/Nativeness and anti-Blackness.
+- Unwelcome comments regarding a person's lifestyle choices and practices, including those related to food, health, parenting, relationships, drugs, and employment.
+- Deliberate misgendering, using inappropriate pronouns, or use of "dead" or rejected names.
+- Gratuitous or off-topic sexual images or behavior in spaces where they're not appropriate.
+- Physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop.
+- Threats of violence.
+- Incitement of violence towards any individual or group, including encouraging a person to commit suicide or to engage in self-harm.
+- Deliberate intimidation.
+- Stalking or following - online or in the physical world.
+- Harassing photography or recording, including logging online activity for harassment purposes.
+- Sustained disruption of discussion.
+- Unwelcome sexual attention.
+- Patterns of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others.
+- Continued one-on-one communication after requests to cease.
+- Deliberate "outing" of any aspect of a person's identity without their consent except as necessary to protect vulnerable people from intentional abuse.
+- Publication of non-harassing private communication.
+- Jokes that resemble the above, such as "hipster racism", still count as harassment even if meant satirically or ironically.
+
+If you have questions or concerns about these issues please feel free to message an admin or ask for an opportunity to explore the issue with a moderator and volunteers.
+
+### Reporting
+
+If you are being harassed by a member of our community, notice that someone else is being harassed, or have any other concerns, please contact the administrators via [codeofconduct@graphql.com](mailto:codeofconduct@graphql.com). If the person who is harassing you is on the admin team, they will not be involved in handling or resolving the incident.
+
+The admin team will respond to any complaint as promptly as possible we can. If you do not get a timely response (for example, if no admins are currently online) then please put your personal safety and well-being first, and consider logging out and/or contacting the admins by email at [codeofconduct@graphql.com](mailto:codeofconduct@graphql.com).
+
+This code of conduct applies to our community's spaces, but if you are being harassed by a member of our community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by our members, especially the administrators, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from the community based on their past behavior, including behavior outside of our spaces and behavior towards people who are not in this community.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+### Enforcement Process
+
+Every code of conduct violation report will be treated with seriousness and care. If a member's immediate safety and security is threatened, an individual admin may take any action that they deem appropriate, up to and including temporarily banning the offender from the community. In less urgent situations, at least two admins will discuss the offense and mutually arrive at a suitable response, which will be shared with the offender privately. Whatever the resolution that they decide upon, the decision of the admins involved in a violation case will be considered final.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we've received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our members or the general public. We will not name harassment victims without their affirmative consent.
+
+GraphQL Summit prioritizes marginalized people’s safety over privileged people’s comfort. The administrators will not act on complaints regarding:
+
+- “Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia”
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+- Communicating in a “tone” you don’t find congenial
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+- The examples listed above are not against the Code of Conduct.
+
+### Consequences
+
+Participants asked to stop any harassing behavior are expected to comply immediately. If a participant engages in harassing behavior, the administrators may take any action they deem appropriate, up to and including expulsion from the community and identification of the participant as a harasser to other members. At the discretion of the admins, or by request, one or more of the parties involved may request to discuss the violation and how to avoid similar situations in the future.
+
+### Acknowledgements
+
+This Code of Conduct is adapted from the Community Covenant ([http://community-covenant.net](http://community-covenant.net/)), version 1.0, available at http://community-covenant.net/version/1/0/. The Community Covenant is an open source effort and is built on codes of conduct that came before it, including the Contributor Covenant (http://contributor-covenant.org/) and the LGBTQ in Tech community code of conduct (http://lgbtq.technology/coc.html).
+
+This CoC also includes material adapted from the LGBTQ in Tech community code of conduct (http://lgbtq.technology/coc.html) beyond what the community covenant includes.
+
+### License
+
+Community Covenant by Coraline Ada Ehmke is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0/). Based on a work at http://community-covenant.net/.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,7 +17,7 @@ This community is dedicated to providing a harassment-free experience for everyo
 
 This code of conduct applies to all of this community's spaces, including public channels, private channels and direct messages, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the administrators.
 
-### Toward a Welcoming and Safe Environment
+### A Welcoming and Safe Environment
 
 We hope to create an environment in which diverse individuals can collaborate and interact in a positive and affirming way. Examples of behavior that contributes to creating this sort of environment include:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -67,7 +67,7 @@ Every code of conduct violation report will be treated with seriousness and care
 
 We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we've received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our members or the general public. We will not name harassment victims without their affirmative consent.
 
-GraphQL Summit prioritizes marginalized people’s safety over privileged people’s comfort. The administrators will not act on complaints regarding:
+Apollo prioritizes marginalized people’s safety over privileged people’s comfort. The administrators will not act on complaints regarding:
 
 - “Reverse”-isms, including "reverse racism," "reverse sexism," and "cisphobia"
 - Reasonable communication of boundaries, such as "leave me alone," "go away," or "I’m not discussing this with you."


### PR DESCRIPTION
In the same way that we now have a GitHub-organization-wide `SECURITY.md` via #1, this
aims to land the same for the `CODE_OF_CONDUCT.md` in this repository, which is the
base repository use for all repos in this organization that do not override it.  In the case of
the Code-of-Conduct (CoC) (and the Security file), it acts as a [community health file](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).

This is nearly an exact copy of our existing code of conduct which lives in
source ashttps://github.com/apollographql/community/blob/master/source/code-of-conduct.md,
and is available in our community documentation at https://www.apollographql.com/docs/community/code-of-conduct/.

The only change is the top-level header is made bigger and _GraphQL Summmit_ is changed to
_Apollo_.