### PR TITLE
Add docs prod/staging workflow templates

### DIFF
--- a/workflow-templates/docs-preview.properties.json
+++ b/workflow-templates/docs-preview.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Docs PR Preview Workflow",
+  "description": "Create a deploy preview on Netlify to review proposed docs changes."
+}

--- a/workflow-templates/docs-preview.yml
+++ b/workflow-templates/docs-preview.yml
@@ -1,0 +1,15 @@
+name: Preview docs on Netlify
+
+on:
+  pull_request:
+    branches:
+      - $default-branch
+    paths:
+      - docs/**
+
+jobs:
+  preview:
+    uses: apollographql/docs/.github/workflows/preview.yml@main
+    secrets:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/workflow-templates/docs-publish.properties.json
+++ b/workflow-templates/docs-publish.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Docs Production Deploy Workflow",
+  "description": "Kick off a production deploy on Netlify when the docs change."
+}

--- a/workflow-templates/docs-publish.yml
+++ b/workflow-templates/docs-publish.yml
@@ -1,0 +1,15 @@
+name: Deploy docs to production
+
+on:
+  push:
+    branches:
+      - $default-branch
+    paths:
+      - docs/**
+
+jobs:
+  publish:
+    uses: apollographql/docs/.github/workflows/publish.yml@main
+    secrets:
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
Our new docs infrastructure relies on GitHub actions to kick off production deploys or build deploy previews for PRs. This adds workflow templates to our org that will allow docs repos to more easily set up these workflows.